### PR TITLE
Add editorconfig rule for markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,7 @@ indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false


### PR DESCRIPTION
We like markdown files and this is a rule that makes our `.editorconfig` file respect markdown syntax of using 2 spaces for new lines.