### PR TITLE
Implemented sticky footer using flexbox.

### DIFF
--- a/src/ui-lib/sass/02-generic/_layout.scss
+++ b/src/ui-lib/sass/02-generic/_layout.scss
@@ -4,3 +4,15 @@ $grav-page-content-inset: $grav-sp-m;
 // The maximum width of the page content
 $grav-page-content-max-width: calc(#{gravy-breakpoint(regular)} - #{2 * $grav-page-content-inset});
 $grav-page-content-max-width-large: calc(#{gravy-breakpoint(large)} - #{2 * $grav-page-content-inset});
+
+// Make body at least as tall as viewport
+// and use flexbox to vertically spread out
+// header, main and footer so that footer
+// appears at bottom of viewport on short
+// pages.
+body {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 100vh;
+}

--- a/src/ui-lib/sass/03-elements/_main.scss
+++ b/src/ui-lib/sass/03-elements/_main.scss
@@ -1,6 +1,11 @@
 main {
   margin-top: 0;
 
+  // Expand to fill remaining viewport height between header
+  // and footer on short pages, so that main content does
+  // not appear vertically centered on the page.
+  flex-grow: 1;
+
   > h1:first-child {
     margin-top: $grav-sp-l;
   }


### PR DESCRIPTION
On pages with not much content (e.g. the error page), the footer can appear in the middle of your viewport. This change ensures it is aligned to the bottom of the viewport - unless there is enough content for the page to be taller than the viewport. In that case, the page scrolls as usual.