### PR TITLE
Web-157 (uneven gap between lines in burger menu)

### DIFF
--- a/src/ui-lib/sass/05-components/01-atoms/06-buttons/_08-toggle-menu.scss
+++ b/src/ui-lib/sass/05-components/01-atoms/06-buttons/_08-toggle-menu.scss
@@ -1,16 +1,17 @@
 .grav-c-toggle-menu {
 
-  $grav-sp-icon: 0.35rem;
-  $grav-tr-icon-hover: 0.1rem;
+  $grav-sp-icon: 7px;
+  $grav-tr-icon-hover: 2px;
   $grav-tr-icon-rotate: 135deg;
   $grav-tr-icon-scale: 1.2;
   $grav-size-icon: 33px;
+  $grav-width-icon: 20px;
 
   display: flex;
   height: $grav-size-icon;
   margin-top: 0;
-  border-style: hidden;
   background: none;
+  border-style: hidden;
 
   &:hover,
   &:active,
@@ -30,7 +31,7 @@
   
   &__icon {
     display: inline-block;
-    width: $grav-sp-m;
+    width: $grav-width-icon;
     height: $grav-st-thickness-medium;
     position: relative;
     margin-top: auto;
@@ -42,7 +43,7 @@
       content: '';
       display: inline-block;
 
-      width: $grav-sp-m;
+      width: $grav-width-icon;
       height: $grav-st-thickness-medium;
       position: absolute;
       left: 0;


### PR DESCRIPTION
Closes ticket WEB-157 
 -changed units from rem to px - as rem's decimal precision seemed to be rounding incorrectly in some browsers, causing the gap offset.
-added new local variable for icon width to keep all sizes in px.

-fixed lint error