### PR TITLE
WEB-154 About us / nav links no-wrap fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildit/gravity-ui-sass",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/ui-lib/sass/05-components/01-atoms/10-navigation/_00-block-link.scss
+++ b/src/ui-lib/sass/05-components/01-atoms/10-navigation/_00-block-link.scss
@@ -8,7 +8,8 @@
   border-style: $grav-st-style;
   color: $grav-co-bg;
   text-decoration: none;
-  
+  white-space: nowrap;
+
 
   &[href] {
     &:link,
@@ -19,12 +20,12 @@
 
     &:active,
     &:hover {
-      
+
       border-color: $grav-co-accent-secondary;
       color: $grav-co-neutral-ashtray;
-    }   
+    }
   }
-  
+
   &:not([href]) {
     border-color: $grav-co-bg;
     color: $grav-co-bg;


### PR DESCRIPTION
added a white-space: nowrap to .grav-c-block-link to avoid this type of issue