### PR TITLE
Aligned baselines of location and jobs in job-list.

### DIFF
--- a/src/ui-lib/sass/05-components/03-organisms/_job-list.scss
+++ b/src/ui-lib/sass/05-components/03-organisms/_job-list.scss
@@ -11,6 +11,7 @@
   > header {
     width: 30%;
     margin-right: $grav-sp-m;
+    flex-shrink: 0;
   }
 
   > ul {

--- a/src/ui-lib/sass/05-components/03-organisms/_job-list.scss
+++ b/src/ui-lib/sass/05-components/03-organisms/_job-list.scss
@@ -4,30 +4,44 @@
   }
 
   @media all and (min-width: gravy-breakpoint(regular)) {
-    display: grid;
-    grid-gap: $grav-sp-m;
-    grid-template-columns: 30% 1fr;
+    display: flex;
+    align-items: baseline;
   }
 
-  > header > p {
-    @include typi(small-text);
-    margin-top: 0;
+  > header {
+    width: 30%;
+    margin-right: $grav-sp-m;
   }
 
   > ul {
     padding-left: 0;
+    flex-grow: 1;
     list-style-type: none;
 
     @media all and (min-width: gravy-breakpoint(small)) {
-      columns: 2;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
     }
 
     @media all and (min-width: gravy-breakpoint(regular)) {
       margin-top: 0;
-    } 
+    }
   }
 
-  li + li {
-    margin-top: $grav-sp-s;
+  li {
+    + li {
+      margin-top: $grav-sp-s;
+    }
+
+    @media all and (min-width: gravy-breakpoint(small)) {
+      $jobs-per-row: 2;
+      width: calc((100% - #{$grav-sp-m}) / #{$jobs-per-row});
+
+      // Remove top margin from first row of job cards
+      &:nth-child(-n + #{$jobs-per-row}) { // stylelint-disable-line max-nesting-depth
+        margin-top: 0;
+      }
+    }
   }
 }


### PR DESCRIPTION
The goal was to make the baseline of the H2 text (the location of the jobs) and the first row of job card text to the right be aligned.

After some trial and error, I found that switching to flexbox to do the layout was the only way the `align-items: baseline;` had the desired effect consistently in Chrome, Firefox and Safari.

Maintaining the CSS grid-based layout didn't work everywhere. Only having flex on the outer `job-list` component but continuing to use CSS columns on the job cards didn't work in Firefox. etc.