### PR TITLE
Fix footer link color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Visited footer links are no longer blue
+
 
 ## [0.6.0]
 

--- a/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_01-page-footer.scss
+++ b/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_01-page-footer.scss
@@ -16,7 +16,8 @@ footer[role=contentinfo] {
     }
   }
 
-  a[href]:link {
+  a[href]:link,
+  a[href]:visited {
     color: $grav-co-neutral-dirty-snow-white;
   }
 
@@ -42,7 +43,7 @@ footer[role=contentinfo] {
   .grav-c-icon {
     height: 1.5em;
     fill: $grav-co-neutral-dirty-snow-white;
-    
+
     &:hover {
       fill: $grav-co-neutral-ashtray;
     }


### PR DESCRIPTION
The "Buildit@wipro digital" link in the footer was appearing in the blue (visited) colour in Firefox. This fixes that.