### PR TITLE
Improved header layout on small viewports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - In the job-listing component, location names and job ads are now baseline aligned
 - Text in navigation block-links no longer wraps
+- Improved header layout on small viewports
 
 ## [0.6.0]
 

--- a/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_00-page-header.scss
+++ b/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_00-page-header.scss
@@ -28,33 +28,26 @@ header[role=banner] {
   }
 
   > div {
-    @include grav-l-container(true);
-    @include clear('after');
+    @include grav-l-container;
+
+    display: flex;
+    flex-wrap: wrap;
     padding-top: $grav-sp-m;
     padding-bottom: $grav-sp-m;
+    align-items: center;
+    justify-content: space-between;
 
     @media (min-width: gravy-breakpoint(medium)) {
-      display: grid;
-      padding-right: $grav-sp-m;
-      padding-left: $grav-sp-m;
-      align-items: center;
-      grid-template-columns: 300px 1fr;
-    }
-
-    @media (min-width: gravy-breakpoint(regular)) {
-      padding-right: 0;
-      padding-left: 0;
+      // Force nav onto same line as logo
+      flex-wrap: nowrap;
     }
   }
 
   .logo-main {
     width: 70%; // 2/3 ish of the space
-    margin: 0 $grav-sp-m;
-    float: left;
 
     @media (min-width: gravy-breakpoint(medium)) {
       width: auto;
-      margin: 0;
     }
   }
 
@@ -69,8 +62,7 @@ header[role=banner] {
   }
 
   .grav-c-toggle-menu {
-    margin-right: $grav-sp-m;
-    float: right;
+    flex-shrink: 0;
 
     @media (min-width: gravy-breakpoint(medium)) {
       display: none;
@@ -92,18 +84,14 @@ header[role=banner] {
   }
 
   .grav-c-nav-menu {
-    @include clear;
-    max-width: $grav-page-content-max-width;
+    // Overflow, so that right edge of navlinks is flush
+    // with screen edge
+    width: calc(100% + #{$grav-page-content-inset});
+    margin-top: 0;
+    flex-shrink: 0;
 
     @media (min-width: gravy-breakpoint(medium)) {
-      position: initial;
-      top: auto;
-      right: auto;
-      justify-self: flex-end;
-    }
-
-    @media (min-width: gravy-breakpoint(large)) {
-      max-width: $grav-page-content-max-width-large;
+      width: auto;
     }
   }
 }


### PR DESCRIPTION
I noticed that on very narrow screens, the vertical alignment between the Buildit logo and the hamburger button wasn't ideal. They were top-aligned rather than centre aligned:

<img width="335" alt="header-alignment" src="https://user-images.githubusercontent.com/16718916/38732223-54465dd8-3f15-11e8-9715-5edc317c7d82.png">

To fix that, I switched from floats to flexbox. That required updating some of the other code - however, I think the end result is a bit tidier overall.

Visually, the header appears identically to before on larger screens (tested in Firefox, Safari and Chrome on Mac).