### PR TITLE
Updates travis to npm ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
   - lts/*
-cache:
-  directories:
-    - node_modules
+before_install:
+  - npm i -g npm@~5.8.0
+
 env:
   global:
     - NPM_TAG_REGEXP="^v([0-9]{1,3}\.){2}[0-9]{1,3}.*$"
@@ -13,7 +13,7 @@ env:
     - secure: "yuOsuEAFh3xvvhiAa1qFqdDJ8UY0jnmFB2Vb5fa88yTlQO8FCV2VWH45vlOAZ1EhEeAo/8LFO1iEV/8ykMQICqTeS+dXUxrut8PpIAccgfRO0OnuebY2KKSADbBKsw+lsMPXuaFNxn0mv0vuHMulX0oPR8f/Zx0ZJGf2jo7NuhUPvJhZPIT8cT9VxAdgk7wMdJ6qGIOla5e8icM14JS9lLg+GegL3ks34OZRJW1ciWPAgz/Qp437ByTutHsaRu+/5GXbCLS0k+vSQOzgB6vpcnG4YAPmVXrcFl2LfM3Tqc7yaC/JjPCY44RXvf3SGlsUy/12pbOZ4YYZ5eCXMwN+605YAHYL2uLelYNmhhTy5pYmJwFeO0MaBzS8QSmilhA6GPd0pjQiV/vA9uF4Mj9eUTK6+Tnw67oAWjND5JKr7cbKzVzK74Y8ekFGJbRCRGR0JoOuT5tDQ49tuYBFGiUc+WeE2FcdkLL6TDF3FJHVQ2VjYm6o4oyK7DhOizS606A1XtwvWWElrsTWLWPldKJiQLvxdAmYbWHzQ0DC3LLsA5ZAp3ZpSBCZKyAivMGpWaHkg/Dl9Y3O96cHQVDZepF/lftGoR2lhxNEzhH0USotJpbPdaKyo+4f1uDm7shzCduBYIngd2eTb/NLjCf5CkLjcOuGr50l7xY6g2UCaDBBtQM=" #SLACK_NOTIFICATION_URL
     - secure: "a9edwLnErePBD3w7nEEkEQBm4XGrFH0SCuQfHx9PHsANP2YTwI7CThmZsyqFYj0SH+h3y16l6jm1gU9HeFFJfbWS5x/JbCJi3U4sX0O6mxANmM5VTR+yC0J85Xzdn/GIHWy842ly1OtEVggtQt+TJPGZaZmjIwZxTrbQNlHprbSENvrJkggUa/x41iwst1C0UalTyhLt/bo2Co3xN7Ct+QOdz6CeBLSVvB0FT3yyONzRR9C8c56qHEh+rZtU1haUZKkEn+4esn72atQ8uVSmvOq9VU02HHsU04Sc2NdceLzrWkPTgpMxoX3ZpHb0EO5Kf6FMmqoPkNynmF/sXCm+zfblSTY/zgXm7BdrThNIFaLMGOSCY/apIibZcO4CimFjT9ohMR5tDs3tWRyrILmmHlU6A5w9BANIGwHiJYr3wn9l4vNBafXAnUTLQU0qWDYB3lcIAXHNiV6KZ4f3CNc/FRU9tf+yN2wxCX3JY5oPFLKZ7SJ6E+t7LpVUwdyxsP+qF9JkoiVp7pi4kUjEtfnT9cdg6PHQ2buRV6Oh1wPNup8+HgDL3Go5hfok8eDisX4V3mTYTlUt9LfJ/vIOIlNDkQ9ZcZm8KhtdGMjGSUKvd5GdLiI/LW2kdlNOXUpG5XvkN8BhqjJfQbihjU5g2D0vFtw4HArz+ZWAtV8xCZ1Dbxg=" #ENCRYPTD_NPM_AUTH_TOKEN environment variable
 install:
-  - npm install
+  - npm ci
 script:
   - npm run-script styleguide
 before_deploy:
@@ -21,20 +21,20 @@ before_deploy:
 deploy:
   # deploy develop to Staging
   - provider: script
-    script: 
-      ~/.local/bin/aws s3 sync dist s3://${STAGING_BUCKET} --delete --region=${STAGING_BUCKET_REGION} --exclude "*" --include "*.html" --content-type "text/html; charset=utf-8" && 
-      ~/.local/bin/aws s3 sync dist s3://${STAGING_BUCKET} --delete --region=${STAGING_BUCKET_REGION} --exclude "*" --include "*.css" --content-type "text/css; charset=utf-8" && 
-      ~/.local/bin/aws s3 sync dist s3://${STAGING_BUCKET} --delete --region=${STAGING_BUCKET_REGION} --exclude "*" --include "*.js" --content-type "application/javascript; charset=utf-8" && 
+    script:
+      ~/.local/bin/aws s3 sync dist s3://${STAGING_BUCKET} --delete --region=${STAGING_BUCKET_REGION} --exclude "*" --include "*.html" --content-type "text/html; charset=utf-8" &&
+      ~/.local/bin/aws s3 sync dist s3://${STAGING_BUCKET} --delete --region=${STAGING_BUCKET_REGION} --exclude "*" --include "*.css" --content-type "text/css; charset=utf-8" &&
+      ~/.local/bin/aws s3 sync dist s3://${STAGING_BUCKET} --delete --region=${STAGING_BUCKET_REGION} --exclude "*" --include "*.js" --content-type "application/javascript; charset=utf-8" &&
       ~/.local/bin/aws s3 sync dist s3://${STAGING_BUCKET} --delete --region=${STAGING_BUCKET_REGION} --include "*" --exclude "*.js" --exclude "*.html" --exclude "*.css"
     skip_cleanup: true
     on:
       branch: develop
   # deploy tags matching v#.#.*  to Production
   - provider: script
-    script: 
-      ~/.local/bin/aws s3 sync dist s3://${PROD_BUCKET} --delete --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.html" --content-type "text/html; charset=utf-8" && 
-      ~/.local/bin/aws s3 sync dist s3://${PROD_BUCKET} --delete --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.css" --content-type "text/css; charset=utf-8" && 
-      ~/.local/bin/aws s3 sync dist s3://${PROD_BUCKET} --delete --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.js" --content-type "application/javascript; charset=utf-8" && 
+    script:
+      ~/.local/bin/aws s3 sync dist s3://${PROD_BUCKET} --delete --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.html" --content-type "text/html; charset=utf-8" &&
+      ~/.local/bin/aws s3 sync dist s3://${PROD_BUCKET} --delete --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.css" --content-type "text/css; charset=utf-8" &&
+      ~/.local/bin/aws s3 sync dist s3://${PROD_BUCKET} --delete --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.js" --content-type "application/javascript; charset=utf-8" &&
       ~/.local/bin/aws s3 sync dist s3://${PROD_BUCKET} --delete --region=${PROD_BUCKET_REGION} --include "*" --exclude "*.js" --exclude "*.html" --exclude "*.css"
     skip_cleanup: true
     on:

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ A SASS UI library from the Buildit's Gravity design system.
 ### Pre-requisites
 
 * [SASS](http://sass-lang.com/) compilation setup in your project
-* `npm` (>= v5.6.0)
-* [Eyeglass](https://github.com/sass-eyeglass/eyeglass) (>= 1.3.0)
+* `npm` (>= v5.8.0)
+* [Eyeglass](https://github.com/sass-eyeglass/eyeglass) (>= 1.4.1)
 
 ### Installation
 
@@ -83,6 +83,19 @@ The build output will go into `dist/` and, in this instance, only contains the a
   * [Naming conventions](./docs/naming-conventions.md)
 * Contribution guidelines (TBC)
 * [`git` branching strategy](./docs/branching-strategy.md)
+
+## Deployment
+
+### Travis CI notes
+The current Travis CI configuration utilises `npm ci` to ensure reproducibility for every build.
+
+`.travis.yml` takes care of installing the correct npm version before running `npm ci`.
+
+To be able to run `npm ci` on your machine, and to be sure to create a `package-lock.json` file compatible with it, make sure to update to npm version 5.8.0.
+
+`.nvmrc` only allows us to specify Node.js version, but that alone is not enough at the moment, since Node.js 8 comes out of the box with npm version 5.6.0.
+
+### Further Information
 * [Release process](./docs/releasing.md)
 * [Travis CI setup](./docs/travis-ci.md) (for automated build & deplpoyments)
-
+* [npm ci docs](https://docs.npmjs.com/cli/ci)

--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
     "normalize-scss": "^7.0.0"
   },
   "engines": {
-    "node": "^8.9.4",
-    "npm": "^5.6.0"
+    "node": "^8.11.1",
+    "npm": "^5.8.0"
   },
   "eyeglass": {
     "sassDir": "src/ui-lib/sass",


### PR DESCRIPTION
This PR updates the minimum required node and npm version.

By switching to `npm ci` we can skip the node_modules caching.

The first built took more time than actually required, I've run a second build to show that the build time is quite good, and we get all the benefits that `npm ci` provides: [https://docs.npmjs.com/cli/ci](https://docs.npmjs.com/cli/ci)