### PR TITLE
Backporting website fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Edge and IE11 were pushing hamburger icon downwards
 - Added margin between logo and navlinks in header
+- Hero text is placed above canvas
+- 2 column block layout (as used in location page template) is flush with outer edges
 
 
 ## [0.6.1] - 2018-04-13

--- a/src/ui-lib/sass/05-components/03-organisms/_hero.scss
+++ b/src/ui-lib/sass/05-components/03-organisms/_hero.scss
@@ -27,4 +27,8 @@
     left: 0;
     margin: 0;
   }
+
+  > :not(canvas) {
+    position: relative;
+  }
 }

--- a/src/ui-lib/sass/05-components/03-organisms/_two-columns-block.scss
+++ b/src/ui-lib/sass/05-components/03-organisms/_two-columns-block.scss
@@ -2,7 +2,7 @@
   @media (min-width: gravy-breakpoint(medium)) {
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-around;
+    justify-content: space-between;
   }
 
   > * {


### PR DESCRIPTION
A couple of CSS fixes were done in the website's code:

* Fix to hero because canvas (with dots animation) was sitting on top of text
* Tweak to locations page layout that makes cards align with outer edges of content area and left aligns last, dangling card

This PR backports those CSS changes into Gravity. Once they work their way into a future Gravity release, they can be deleted from the website's code.