### PR TITLE
Fix IE burger menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Fixed
+- Toggle buttons (incl. hamburger menu button) now work in IE11
+- Header now has normal height in IE11 on small screens
 
 
 ## [0.7.0] - 2018-04-19

--- a/src/ui-lib/js/gravity.js
+++ b/src/ui-lib/js/gravity.js
@@ -33,8 +33,10 @@
   function initToggleButtons() {
     const toggleButtons = document.querySelectorAll('[type=button][aria-pressed]');
 
-    toggleButtons.forEach((toggleButton) => {
-      toggleButton.addEventListener('click', (e) => {
+    // IE-compatible way of iterating over the NodeList
+    // (See: https://developer.mozilla.org/en-US/docs/Web/API/NodeList)
+    Array.prototype.forEach.call(toggleButtons, function(toggleButton) {
+      toggleButton.addEventListener('click', function(e) {
         let pressed = toggleButton.getAttribute('aria-pressed') === 'true';
         toggleButton.setAttribute('aria-pressed', String(!pressed));
       })
@@ -44,7 +46,7 @@
   /**
    * Runs the various init functions once the DOM has loaded.
    */
-  document.addEventListener("DOMContentLoaded", (e) => {
+  document.addEventListener("DOMContentLoaded", function(e) {
     initToggleButtons();
   });
 

--- a/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_00-page-header.scss
+++ b/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_00-page-header.scss
@@ -53,11 +53,13 @@ header[role=banner] {
 
   .grav-c-logo {
     display: block;
+    max-height: 33px; // Otherwise IE11 makes it 150px tall :-(
     fill: $grav-co-bg;
 
     // Bump up logo size
     @media (min-width: gravy-breakpoint(medium)) {
       height: 2.5rem;
+      max-height: none;
     }
   }
 


### PR DESCRIPTION
In IE11 clicking the burger menu on small screens had no effect. Therefore, the navigation links were inaccessible.

It turns out that IE11 doesn't support arrow functions and also it doesn't have the `forEach()` method on the `NodeList` returned by `document.querySelectorAll();`. Therefore the JS execution died and the menu didn't work.

Additionally, the header was appearing excessively tall on IE11. It turned out to be the logo SVG. We have `height: auto;` which defaults to `150px` for inline SVGs but _should_ be overridden by the SVG's `height` attribute if one is set. It turns out that IE11 was ignoring the SVG's `height` attribute and therefore using the `150px` default instead. Setting a `max-height: 33px;` in the CSS fixed this (without adversely affecting other browsers).

This PR fixes both these issues.