### PR TITLE
Bug Fix (WEB-204): Changed inline text link colour on active state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - `<header role="banner">` page title now has a hover state across all pages
+
 ### Changed
 - `a[href]` has new contrast appropriate active state text colour in `inline-text`. Set to override visited state.
+
 ### Fixed
 - `<a>` elements now are no longer smaller than their child elements in `list-inline-row` by being set to inline-block.
+
 ### Removed
 - unecessary background for `<a>` element in active state 
+
+
 ## [0.8.0] - 2018-04-25
 ### Added
 - Hollow version of Buildit logo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ### Fixed
-- `a[href]` has new contrast appropriate active state text colour for  in `inline-text` that also overrides the visited state.
+- `a[href]` has new contrast appropriate active state text colour for  in `inline-text` that works better across all background colors also overrides the visited state.
+- removed unecessary background for `<a>` elements in active state 
 - `<a>` elements now are no longer smaller than their child elements in `list-inline-row` by being set to inline-block.
-- `<a>` has a transparent background active state `list-inline-row` to override default.
 - `<header role="banner">` page title now has a hover state across all pages
 
 ## [0.8.0] - 2018-04-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ### Fixed
-- `a[href]` has new contrast appropriate active state text colour for  in `inline-text` that works better across all background colors also overrides the visited state.
-- removed unecessary background for `<a>` elements in active state 
+- `a[href]` has new contrast appropriate active state text colour in `inline-text`. Set to override state.
+- removed unecessary background for `<a>` element in active state 
 - `<a>` elements now are no longer smaller than their child elements in `list-inline-row` by being set to inline-block.
 - `<header role="banner">` page title now has a hover state across all pages
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 
+
+### Fixed
+- `a[href]` has new contrast appropriate active state text colour for  in `inline-text` that also overrides the visited state.
+- `<a>` elements now are no longer smaller than their child elements in `list-inline-row` by being set to inline-block.
+- `<a>` has a transparent background active state `list-inline-row` to override default.
+- `<header role="banner">` page title now has a hover state across all pages
+
 ## [0.8.0] - 2018-04-25
 ### Added
 - Hollow version of Buildit logo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
-### Fixed
-- `a[href]` has new contrast appropriate active state text colour in `inline-text`. Set to override visited state.
-- removed unecessary background for `<a>` element in active state 
-- `<a>` elements now are no longer smaller than their child elements in `list-inline-row` by being set to inline-block.
+### Added
 - `<header role="banner">` page title now has a hover state across all pages
-
+### Changed
+- `a[href]` has new contrast appropriate active state text colour in `inline-text`. Set to override visited state.
+### Fixed
+- `<a>` elements now are no longer smaller than their child elements in `list-inline-row` by being set to inline-block.
+### Removed
+- unecessary background for `<a>` element in active state 
 ## [0.8.0] - 2018-04-25
 ### Added
 - Hollow version of Buildit logo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ### Fixed
-- `a[href]` has new contrast appropriate active state text colour in `inline-text`. Set to override state.
+- `a[href]` has new contrast appropriate active state text colour in `inline-text`. Set to override visited state.
 - removed unecessary background for `<a>` element in active state 
 - `<a>` elements now are no longer smaller than their child elements in `list-inline-row` by being set to inline-block.
 - `<header role="banner">` page title now has a hover state across all pages

--- a/src/ui-lib/sass/03-elements/_inline-text.scss
+++ b/src/ui-lib/sass/03-elements/_inline-text.scss
@@ -15,7 +15,7 @@ a[href] {
 
   &:active {
     background: $grav-co-interactive-secondary;
-    color: $grav-co-neutral-dirty-snow-white;
+    color: $grav-co-interactive-secondary-contrast;
   }
   
 }

--- a/src/ui-lib/sass/03-elements/_inline-text.scss
+++ b/src/ui-lib/sass/03-elements/_inline-text.scss
@@ -9,14 +9,15 @@ a[href] {
     color: $grav-co-interactive-secondary-hover;
   }
 
-  &:active {
-    background: $grav-co-interactive-secondary;
-    color: inherit;
-  }
-
   &:visited {
     color: $grav-co-interactive-secondary-visited;
   }
+
+  &:active {
+    background: $grav-co-interactive-secondary;
+    color: $grav-co-neutral-dirty-snow-white;
+  }
+  
 }
 
 b,

--- a/src/ui-lib/sass/03-elements/_inline-text.scss
+++ b/src/ui-lib/sass/03-elements/_inline-text.scss
@@ -14,8 +14,7 @@ a[href] {
   }
 
   &:active {
-    background: $grav-co-interactive-secondary;
-    color: $grav-co-interactive-secondary-contrast;
+    color: $grav-co-accent-primary-light;
   }
   
 }

--- a/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_00-page-header.scss
+++ b/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_00-page-header.scss
@@ -4,7 +4,6 @@
 // width ($grav-page-content-max-width) themselves, where necessary.
 header[role=banner] {
   background-color: $grav-co-neutral-charcoal;
-  
 
   &.is-light { // stylelint-disable selector-no-qualifying-type
     background-color: transparent;
@@ -56,10 +55,6 @@ header[role=banner] {
     display: block;
     max-height: 33px; // Otherwise IE11 makes it 150px tall :-(
     fill: $grav-co-bg;
-
-    &:hover {
-      fill: $grav-co-neutral-ashtray;
-    }
 
     // Bump up logo size
     @media (min-width: gravy-breakpoint(medium)) {

--- a/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_00-page-header.scss
+++ b/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_00-page-header.scss
@@ -4,6 +4,7 @@
 // width ($grav-page-content-max-width) themselves, where necessary.
 header[role=banner] {
   background-color: $grav-co-neutral-charcoal;
+  
 
   &.is-light { // stylelint-disable selector-no-qualifying-type
     background-color: transparent;
@@ -55,6 +56,10 @@ header[role=banner] {
     display: block;
     max-height: 33px; // Otherwise IE11 makes it 150px tall :-(
     fill: $grav-co-bg;
+
+    &:hover {
+      fill: $grav-co-neutral-ashtray;
+    }
 
     // Bump up logo size
     @media (min-width: gravy-breakpoint(medium)) {


### PR DESCRIPTION
Changed inline text link colour on active state. 

Move active below visited for specificity - so that active overrides the visited colour.