### PR TITLE
Bug Fix (WEB-209): dark background block that only covers half of the logo's background 

### DIFF
--- a/src/ui-lib/sass/05-components/03-organisms/_list-inline-row.scss
+++ b/src/ui-lib/sass/05-components/03-organisms/_list-inline-row.scss
@@ -15,6 +15,7 @@
   }
 
   a {
+    display: inline-block;
     text-decoration: underline;
 
     &:hover {

--- a/src/ui-lib/sass/05-components/03-organisms/_list-inline-row.scss
+++ b/src/ui-lib/sass/05-components/03-organisms/_list-inline-row.scss
@@ -21,6 +21,10 @@
     &:hover {
       color: $grav-co-neutral-asphalt;
     }
+    
+    &:active {
+      background: transparent;
+    }
   }
 
   svg {


### PR DESCRIPTION
Closes ticket WEB-209 (Change partner logo link background colour on active state)

Set background to transparent to anchor elements inside list-inline-row.

Set anchor to inline-block to enable its children to fit inside of it, fixing the original issue of the background only covering half of its child elements.