### PR TITLE
Bug Fix (WEB-214) Target IE10+ for tools > container

### DIFF
--- a/src/ui-lib/sass/01-tools/_container.scss
+++ b/src/ui-lib/sass/01-tools/_container.scss
@@ -2,6 +2,9 @@
 @mixin grav-l-container($no-margin: false) {
   max-width: $grav-page-content-max-width;
 
+  // IE10+ bug that happens when using margin: auto
+  // to fill all the available space between flex items.
+  // More info: https://github.com/philipwalton/flexbugs#flexbug-15
   @media (-ms-high-contrast: none), (-ms-high-contrast: active) {
     width: $grav-page-content-max-width;
   }

--- a/src/ui-lib/sass/01-tools/_container.scss
+++ b/src/ui-lib/sass/01-tools/_container.scss
@@ -2,18 +2,13 @@
 @mixin grav-l-container($no-margin: false) {
   max-width: $grav-page-content-max-width;
 
-  @media (-ms-high-contrast: none), (-ms-high-contrast: active) {
-    width: $grav-page-content-max-width;
-  }
-
   @if (not $no-margin) {
     margin-right: $grav-page-content-inset;
     margin-left: $grav-page-content-inset;
   }
 
   @media (min-width: gravy-breakpoint(regular)) {
-    margin-right: auto;
-    margin-left: auto;
+    align-items: center;
   }
 
   @media (min-width: gravy-breakpoint(large)) {

--- a/src/ui-lib/sass/01-tools/_container.scss
+++ b/src/ui-lib/sass/01-tools/_container.scss
@@ -2,13 +2,18 @@
 @mixin grav-l-container($no-margin: false) {
   max-width: $grav-page-content-max-width;
 
+  @media (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    width: $grav-page-content-max-width;
+  }
+
   @if (not $no-margin) {
     margin-right: $grav-page-content-inset;
     margin-left: $grav-page-content-inset;
   }
 
   @media (min-width: gravy-breakpoint(regular)) {
-    align-items: center;
+    margin-right: auto;
+    margin-left: auto;
   }
 
   @media (min-width: gravy-breakpoint(large)) {

--- a/src/ui-lib/sass/01-tools/_container.scss
+++ b/src/ui-lib/sass/01-tools/_container.scss
@@ -2,6 +2,10 @@
 @mixin grav-l-container($no-margin: false) {
   max-width: $grav-page-content-max-width;
 
+  @media (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    width: $grav-page-content-max-width;
+  }
+
   @if (not $no-margin) {
     margin-right: $grav-page-content-inset;
     margin-left: $grav-page-content-inset;


### PR DESCRIPTION
This is [a IE11 bug](https://digitalrig.atlassian.net/browse/WEB-214) that happens when using margin: auto to fill all the available space between flex items. Here's more info [about this bug](https://github.com/philipwalton/flexbugs#flexbug-15)
