### PR TITLE
Page header & footer markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Github link in page footers
 
+### Changed
+- Page header no longer uses `role="banner"`
+- Page footer no longer uses `role="contentinfo"`
+
 ### Fixed
 - Display of social media icons in style guide
 

--- a/src/styleguide/_patterns/03-organisms/00-page-structure/00-page-header.mustache
+++ b/src/styleguide/_patterns/03-organisms/00-page-structure/00-page-header.mustache
@@ -1,4 +1,4 @@
-<header role="banner"{{#header.light}} class="is-light"{{/header.light}}>
+<header{{#header.light}} class="is-light"{{/header.light}}>
   <div>
     <div class="logo-main">
       <a href="{{{header.url}}}">

--- a/src/styleguide/_patterns/03-organisms/00-page-structure/01-page-footer.mustache
+++ b/src/styleguide/_patterns/03-organisms/00-page-structure/01-page-footer.mustache
@@ -1,4 +1,4 @@
-<footer role="contentinfo" class="{{styleModifier}}">
+<footer class="{{styleModifier}}">
   <p>{{footer.copy}} <a href="{{{url}}}">{{> atoms-logotype(label: "buildit @ wipro digital") }}</a></p>
   <ul class="grav-c-list-horizontal">
     {{#footer.social}}

--- a/src/ui-lib/sass/02-generic/_heydon.scss
+++ b/src/ui-lib/sass/02-generic/_heydon.scss
@@ -40,6 +40,6 @@ dd,
 th,
 td,
 option,
-header[role=banner] {
+body > header {
   margin-top: 0;
 }

--- a/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_00-page-header.scss
+++ b/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_00-page-header.scss
@@ -2,7 +2,7 @@
 // is in case we want to give it any kind of full-bleed background styling.
 // The child elements within therefore need to respect the maximum content
 // width ($grav-page-content-max-width) themselves, where necessary.
-header[role=banner] {
+body > header {
   background-color: $grav-co-neutral-charcoal;
 
   &.is-light { // stylelint-disable selector-no-qualifying-type
@@ -70,6 +70,7 @@ header[role=banner] {
       display: none;
     }
 
+    /* stylelint-disable-next-line selector-max-compound-selectors */
     &[aria-pressed] ~ .grav-c-nav-menu,
     &[aria-pressed='false'] ~ .grav-c-nav-menu {
       display: none;
@@ -80,6 +81,7 @@ header[role=banner] {
       }
     }
 
+    /* stylelint-disable-next-line selector-max-compound-selectors */
     &[aria-pressed='true'] ~ .grav-c-nav-menu {
       display: block;
     }

--- a/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_00-page-header.scss
+++ b/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_00-page-header.scss
@@ -17,7 +17,8 @@ body > header {
       fill: $grav-co-neutral-warm-grey;
     }
 
-    .grav-c-block-link {
+    .grav-c-block-link:link,
+    .grav-c-block-link:visited {
       background-color: $grav-co-bg;
       color: $grav-co-neutral-asphalt;
     }

--- a/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_01-page-footer.scss
+++ b/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_01-page-footer.scss
@@ -1,4 +1,4 @@
-footer[role=contentinfo] {
+body > footer {
   @include typi('small-text');
   margin-top: vr(3);
   padding: $grav-sp-l 0;


### PR DESCRIPTION
According to the HTML validator, using `role="banner"` on a `<header>`, which is a direct descendant of `<body>` is redundant as those semantics are already implicit. Likewise, `role="contentinfo"` on `<footer>` is redundant as well.

This PR therefore removes those attributes from the patterns and updates the CSS accordingly. Consumers of Gravity don't _have to_ update their markup (the new CSS simply targets the elements rather than the attribute), so this is not a breaking change. However, they are strongly encouraged to do so, in order to avoid HTML validation warnings.