### PR TITLE
Separated toggle-menu button from nav-menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Changed
+- Separated toggle-menu button from nav-menu in pattern library
 
 
 ## [0.10.0] - 2018-05-23

--- a/src/styleguide/_patterns/02-molecules/00-navigation/00-nav-menu.mustache
+++ b/src/styleguide/_patterns/02-molecules/00-navigation/00-nav-menu.mustache
@@ -1,4 +1,3 @@
-{{> atoms-toggle-menu }}
 <nav class="grav-c-nav-menu">
   <ul>
   {{#links}}

--- a/src/styleguide/_patterns/03-organisms/00-page-structure/00-page-header.mustache
+++ b/src/styleguide/_patterns/03-organisms/00-page-structure/00-page-header.mustache
@@ -15,6 +15,7 @@
       </h1>
       {{/header.url}}
     </div>
+    {{> atoms-toggle-menu }}
     {{> molecules-nav-menu }}
   </div>
 </header>

--- a/src/ui-lib/sass/05-components/02-molecules/00-navigation/_00-nav-menu.scss
+++ b/src/ui-lib/sass/05-components/02-molecules/00-navigation/_00-nav-menu.scss
@@ -1,16 +1,9 @@
 .grav-c-nav-menu {
   $trigger-breakpoint: gravy-breakpoint(medium);
-  width: 100%;
   text-align: right;
-  margin: 0;
-
-  @media (min-width: $trigger-breakpoint) {
-    width: auto;
-    margin-top: $grav-sp-m;
-  }
 
   > ul {
-    margin: $grav-sp-s (-$grav-sp-s) 0;
+    margin: 0 (-$grav-sp-s);
     padding: 0;
     list-style-type: none;
 

--- a/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_00-page-header.scss
+++ b/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_00-page-header.scss
@@ -4,7 +4,9 @@ $grav-page-heading-logo-width: 250px;
 // is in case we want to give it any kind of full-bleed background styling.
 // The child elements within therefore need to respect the maximum content
 // width ($grav-page-content-max-width) themselves, where necessary.
-body > header { 
+body > header {
+  $trigger-breakpoint: gravy-breakpoint(medium);
+
   > div {
     @include grav-l-container;
 
@@ -15,7 +17,7 @@ body > header {
     align-items: center;
     justify-content: space-between;
 
-    @media (min-width: gravy-breakpoint(medium)) {
+    @media (min-width: $trigger-breakpoint) {
       padding-top: 0;
     }
   }
@@ -23,7 +25,7 @@ body > header {
   .logo-main {
     width: 70%; // 2/3 ish of the space
 
-    @media (min-width: gravy-breakpoint(medium)) {
+    @media (min-width: $trigger-breakpoint) {
       max-width: 250px;
       margin: $grav-sp-m $grav-sp-m 0 0;
       flex-shrink: 0;
@@ -35,7 +37,7 @@ body > header {
     max-height: 33px; // Otherwise IE11 makes it 150px tall :-(
     fill: $grav-co-neutral-asphalt;
 
-    @media (min-width: gravy-breakpoint(medium)) {
+    @media (min-width: $trigger-breakpoint) {
       width: 100%;
     }
   }
@@ -48,7 +50,7 @@ body > header {
   .grav-c-toggle-menu {
     flex-shrink: 0;
 
-    @media (min-width: gravy-breakpoint(medium)) {
+    @media (min-width: $trigger-breakpoint) {
       display: none;
     }
 
@@ -57,7 +59,7 @@ body > header {
     &[aria-pressed='false'] ~ .grav-c-nav-menu {
       display: none;
 
-      @media (min-width: gravy-breakpoint(medium)) { // stylelint-disable max-nesting-depth
+      @media (min-width: $trigger-breakpoint) { // stylelint-disable-line max-nesting-depth
         display: flex;
       }
     }
@@ -66,9 +68,19 @@ body > header {
     &[aria-pressed='true'] ~ .grav-c-nav-menu {
       display: block;
 
-      @media (min-width: gravy-breakpoint(medium)) {
+      @media (min-width: $trigger-breakpoint) { // stylelint-disable-line max-nesting-depth
         display: flex;
       }
+    }
+  }
+
+  .grav-c-nav-menu {
+    width: 100%;
+    margin-top: $grav-sp-s;
+
+    @media (min-width: $trigger-breakpoint) {
+      width: auto;
+      margin-top: $grav-sp-m;
     }
   }
 }


### PR DESCRIPTION
Closes #131

This PR splits out the `toggle-menu` button from the `nav-menu` component, so that when the menu is viewed by itself in the pattern library, it is always visible.

Some of the associated CSS has been shuffled around a bit and simplified as well.


### Overall Approach

- [x] The code is written with a _content-first_ and _mobile-first_ approach.
- [x] The code has been tested across the major desktop browsers (Chrome, Firefox, Edge, Safari) and mobile browsers (Chrome, Samsung Internet, Safari) to work consistently.
- [x] The code should _degrade gracefully_ on older browsers (please provide an example on how this is the case).

### Files

#### JSON

- [x] Variables are not passed to patterns, unless the pattern requires so.
- [x] All variables are used and defined in the main `_data.json` file.
- [x] Overridden variables appear mostly in `pages`.

#### Patterns/templates

- [x] The patterns are devoid of any actual copy, the copy belongs to JSON files (see above).
- [x] The patterns follow the [10 principles of inclusive web design](https://www.designprinciplesftw.com/collections/the-ten-principles-of-inclusive-web-design) which Gravity adheres to.
- [x] The patterns have been tested within their intended use and in isolation 
- [x] The patterns should be styled _context-free_ (see above), e.g. no vertical margins should be set, the container should take care of that.

#### SASS

- [x] The SASS (and related pattern files) follow the [naming conventions](/docs/naming-conventions.md), architecture and structure outlined in the documentation.

#### Other (images)

- [x] The images have been added to Gravity only if specifically needed, otherwise they should belong to PatternLab itself (there are some live examples in the code base).
- [x] Documentation for any new feature and functionality has been added.
- [x] The `CHANGELOG.md` has been updated.
