### PR TITLE
Migrate to .huskyrc file

### DIFF
--- a/.huskyrc.json
+++ b/.huskyrc.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "pre-commit": "npm run lint"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "styleguide": "gulp styleguide",
     "start": "gulp serve",
     "test": "npm run lint",
-    "lint": "stylelint 'src/ui-lib/sass/**/*.scss'",
-    "precommit": "npm run lint"
+    "lint": "stylelint 'src/ui-lib/sass/**/*.scss'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
During `npm install`, `husky` was displaying a warning message that using `package.json`'s `scripts.pre-commit` was deprecated and you should migrate to either adding a `husky` section inside `package.json` or else using a Husky config file.

This PR implements the latter.

Note, no need to update the changelog as the unreleased changes still include the addition of Husky in the first place.