### PR TITLE
fix(releases): releases now always trigger on master instead of by tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ script:
 before_deploy:
   - pip install --user awscli
 deploy:
+  - provider: script
+    skip_cleanup: true
+    script:
+      npx semantic-release
   # deploy develop to Staging
   - provider: script
     script:
@@ -33,12 +37,7 @@ deploy:
       ~/.local/bin/aws s3 sync dist s3://${PROD_BUCKET} --delete --region=${PROD_BUCKET_REGION} --include "*" --exclude "*.js" --exclude "*.html" --exclude "*.css"
     skip_cleanup: true
     on:
-      tags: true
-      condition: $TRAVIS_TAG =~ $PROD_TAG_REGEXP
-  - provider: script
-    skip_cleanup: true
-    script:
-      npx semantic-release
+      branch: master
 notifications:
   slack:
     rooms:


### PR DESCRIPTION
This fixes `master` releases to always trigger them whenever something is merged into the branch.

PS This is a hotfix so it should be released with GitFlow's hotfix tool. Meaning it's branched off of `master` and merged into `master` and `develop`