### PR TITLE
Fixes layout for lists

### DIFF
--- a/src/ui-lib/sass/03-elements/_lists.scss
+++ b/src/ui-lib/sass/03-elements/_lists.scss
@@ -1,13 +1,17 @@
 ul,
 ol {
-  padding-left: 0;
-  list-style-position: inside;
+  padding-left: $grav-sp-l;
+}
 
-  @media all and (min-width: gravy-breakpoint(regular)) {
-    list-style-position: outside;
-  }
+li + li {
+  // Decrease default vertical space
+  // between successive list items
+  margin-top: $grav-sp-m;
+}
 
-  li + li {
-    margin-top: $grav-sp-m;
-  }
+li > ul,
+li > ol {
+  // Add space above nested lists and their
+  // parent list item's text
+  margin-top: $grav-sp-m;
 }


### PR DESCRIPTION
Closes #173

**Description**
The base styles for &lt;ul> and &lt;ol> had 2 issues: Nested lists were not indented and on some viewport sizes bullets would overflow to the left. This commit fixes those issues.

**Checklist**
Visually checked other patterns that use lists to ensure that they haven't been broken by these changes. Everything looks fine.

Setup a nested list to check that indentation now works. Here's a screenshot:
<img width="637" alt="image" src="https://user-images.githubusercontent.com/16718916/54214464-2a065f80-44de-11e9-8524-877595637754.png">

