### PR TITLE
fix: pin eyeglass to 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "commitizen": "^3.0.7",
     "cz-conventional-changelog": "^2.1.0",
     "del": "^4.0.0",
-    "eyeglass": "^2.2.1",
+    "eyeglass": "2.2.1",
     "gulp": "^4.0.0",
     "gulp-cheerio": "^0.6.3",
     "gulp-filter": "^5.1.0",


### PR DESCRIPTION
Closes #197 

**Description**
Pegs our Eyeglass dependency to `2.2.1` because subsequent versions have a bug that breaks the build. (I have raised an issue with them, and once it's fixed, we should un-peg and upgrade this to the latest version.
