### PR TITLE
Rename to gravity-ui-web

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,4 +4,4 @@ Closes #000 (replace with the issue ID(s) of any related issues that will be clo
 What does this PR do or fix?
 
 **Checklist**
-Indicate what checks or tests you have completed here. You can copy-paste relevant items from our [Pull Request checklist](https://raw.githubusercontent.com/buildit/gravity-ui-sass/develop/docs/pr-checklist.md).
+Indicate what checks or tests you have completed here. You can copy-paste relevant items from our [Pull Request checklist](https://raw.githubusercontent.com/buildit/gravity-ui-web/develop/docs/pr-checklist.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,19 @@
-## [0.12.1](https://github.com/buildit/gravity-ui-sass/compare/v0.12.0...v0.12.1) (2019-03-05)
+## [0.12.1](https://github.com/buildit/gravity-ui-web/compare/v0.12.0...v0.12.1) (2019-03-05)
 
 
 ### Bug Fixes
 
-* **releases:** releases now always trigger on master instead of by tag ([0f2e23f](https://github.com/buildit/gravity-ui-sass/commit/0f2e23f))
+* **releases:** releases now always trigger on master instead of by tag ([0f2e23f](https://github.com/buildit/gravity-ui-web/commit/0f2e23f))
 
-# [0.12.0](https://github.com/buildit/gravity-ui-sass/compare/v0.11.1...v0.12.0) (2019-03-05)
+# [0.12.0](https://github.com/buildit/gravity-ui-web/compare/v0.11.1...v0.12.0) (2019-03-05)
 
 
 ### Features
 
-* **package.json:** added support for Semantic Release ([4292a3a](https://github.com/buildit/gravity-ui-sass/commit/4292a3a))
+* **package.json:** added support for Semantic Release ([4292a3a](https://github.com/buildit/gravity-ui-web/commit/4292a3a))
 
 # Changelog
-All notable changes to the [`gravity-ui-sass` project](./README.md) will be documented in this file.
+All notable changes to the [`gravity-ui-web` project](./README.md) will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
@@ -248,7 +248,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - NVM config
 - Basic font styles
 - Normalize and modularscale SASS libs
-- `gravity-ui-sass` is now an [SASS Eyeglass](https://github.com/sass-eyeglass/eyeglass) module
+- `gravity-ui-web` is now an [SASS Eyeglass](https://github.com/sass-eyeglass/eyeglass) module
 - Package now exposes paths to CSS and SASS to cosnumers via its main entry point (`index.js`)
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-We welcome all forms of contribution! Feedback, [bug reports](https://github.com/buildit/gravity-ui-sass/issues/new?template=bug-report.md) and [feature requests](https://github.com/buildit/gravity-ui-sass/issues/new?template=feature-request.md) can be just as valuable as code contributions!
+We welcome all forms of contribution! Feedback, [bug reports](https://github.com/buildit/gravity-ui-web/issues/new?template=bug-report.md) and [feature requests](https://github.com/buildit/gravity-ui-web/issues/new?template=feature-request.md) can be just as valuable as code contributions!
 
 If you want to make code contributions, please follow the process outlined below. Whether you have a specific fix or feature in mind already, or if you have spare time and just want to help out - we'd love to hear from you!
 
@@ -18,7 +18,7 @@ To avoid wasted effort, please always follow this process:
     * As per our [branching strategy](./docs/branching-strategy.md)
 1. **Write your code**
     * Make sure you follow all the relevant conventions (see next section)
-1. **[Create a pull request](https://github.com/buildit/gravity-ui-sass/pulls)** once your code is ready
+1. **[Create a pull request](https://github.com/buildit/gravity-ui-web/pulls)** once your code is ready
     * The maintainers will then review your code and, if necessary, request changes
     * Once approved, your PR will be merged and the associated feature branch will be deleted.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# gravity-ui-sass
+# gravity-ui-web
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/buildit/gravity-ui-sass.svg)](https://greenkeeper.io/)
+[![Greenkeeper badge](https://badges.greenkeeper.io/buildit/gravity-ui-web.svg)](https://greenkeeper.io/)
 
-A SASS UI library from the Buildit's Gravity design system.
+Library of styles, components and associated assets to build UIs for the web. Part of Buildit's Gravity design system.
 
 ---
 
@@ -42,12 +42,12 @@ If you intend to compile Gravity's SASS yourself, we strong recommend:
 ### Installation
 
 ```bash
-$ npm install --save-dev @buildit/gravity-ui-sass
+$ npm install --save-dev @buildit/gravity-ui-web
 ```
 
 ### Build integration
 
-Once installed as a dependency, you need to integrate Gravity into your project's build. The [Gravity UI library NPM package](https://www.npmjs.com/package/@buildit/gravity-ui-sass) ships with the following files:
+Once installed as a dependency, you need to integrate Gravity into your project's build. The [Gravity UI library NPM package](https://www.npmjs.com/package/@buildit/gravity-ui-web) ships with the following files:
 
 * **Pre-compiled CSS file**
     * The SASS source from which the CSS was compiled
@@ -70,32 +70,32 @@ You need to get Gravity's CSS into your website or app somehow. Possible strateg
     For example:
     ```
     // === Settings layer ===
-    @import 'gravity-ui-sass/00-settings/settings.all';
+    @import 'gravity-ui-web/00-settings/settings.all';
 
     // === Tools layer ===
-    @import 'gravity-ui-sass/01-tools/tools.all';
+    @import 'gravity-ui-web/01-tools/tools.all';
     @import 'components/<YOUR_TOOL_NAME>.scss';
 
     // === Generic layer ===
     @import 'normalize';
-    @import 'gravity-ui-sass/02-generic/generic.all';
+    @import 'gravity-ui-web/02-generic/generic.all';
 
     // === Elements layer ===
-    @import 'gravity-ui-sass/03-elements/elements.all';
+    @import 'gravity-ui-web/03-elements/elements.all';
 
     // === Objects layer ===
-    @import 'gravity-ui-sass/04-objects/objects.all';
+    @import 'gravity-ui-web/04-objects/objects.all';
 
     // === Components layer ===
-    @import 'gravity-ui-sass/05-components/components.all';
+    @import 'gravity-ui-web/05-components/components.all';
     @import 'components/<YOUR_COMPONENT_NAME>.scss';
 
     // === Utilities layer ===
-    @import 'gravity-ui-sass/06-utilities/utilities.all';
+    @import 'gravity-ui-web/06-utilities/utilities.all';
     ```
 
     If this is not a requirement then you can simply include all of Gravty's SASS using:
-    `@import 'gravity-ui-sass';
+    `@import 'gravity-ui-web';
 
 * Embedding Gravity's CSS in a bundle
     * `import`ing Gravity's CSS or SASS into a JS bundle (with the appropriate loaders setup) is a perfectly valid approach
@@ -171,7 +171,7 @@ Each component also has notes (shown in the pattern info panel) which describe w
 
 ### One-time setup
 
-1. Clone this repo: https://github.com/buildit/gravity-ui-sass
+1. Clone this repo: https://github.com/buildit/gravity-ui-web
 1. Run `npm install` to install all the dev dependencies
 
 ### Building and running the pattern library locally
@@ -208,7 +208,7 @@ To only build the UI library (without the pattern library), use:
 $ npm run build
 ```
 
-The build output will go into `dist/` and, in this instance, only contains the artefacts that are needed when publishing the [`@buildit/gravity-ui-sass` NPM package](https://www.npmjs.com/package/@buildit/gravity-ui-sass).
+The build output will go into `dist/` and, in this instance, only contains the artefacts that are needed when publishing the [`@buildit/gravity-ui-web` NPM package](https://www.npmjs.com/package/@buildit/gravity-ui-web).
 
 
 ### Making commits

--- a/build-api.js
+++ b/build-api.js
@@ -1,6 +1,6 @@
 /**
  * Provides programatic access to CSS, asset and SASS file paths
- * that are published by the gravity-ui-sass NPM package.
+ * that are published by the gravity-ui-web NPM package.
  *
  * This is so that consumers of this package can access those files
  * in their own build processes (e.g. to copy them to their build dir)

--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -39,4 +39,4 @@ The `master` branch always contains the most recent _production ready_ code.
 
 This has been configured as a restricted branch on GitHub and only project maintainers are able to push to this branch (or merge pull requests into it).
 
-After being merged into `master`, new releases are tagged using the semver format (`v1.2.3`) by the project maintainers. This then triggers an automated build and deployment of both the [Buildit Living Style Guide](http://style.buildit.digital/) and the [`@buildit/gravity-ui-sass` NPM package](https://www.npmjs.com/package/@buildit/gravity-ui-sass).
+After being merged into `master`, new releases are tagged using the semver format (`v1.2.3`) by the project maintainers. This then triggers an automated build and deployment of both the [Buildit Living Style Guide](http://style.buildit.digital/) and the [`@buildit/gravity-ui-web` NPM package](https://www.npmjs.com/package/@buildit/gravity-ui-web).

--- a/docs/build-api.md
+++ b/docs/build-api.md
@@ -1,16 +1,16 @@
 # Build API
 
-The `@buildit/gravity-ui-sass` NPM package provides a Node.js API for build scripts to use. It provides file names and paths to the relevant assets contained in the NPM package, as well as useful metadata about the package.
+The `@buildit/gravity-ui-web` NPM package provides a Node.js API for build scripts to use. It provides file names and paths to the relevant assets contained in the NPM package, as well as useful metadata about the package.
 
-Projects that use Gravity's UI library are **strongly encouraged** to use this API within their build scripts (e.g. [Gulp](https://gulpjs.com/) files or [Webpack](https://webpack.js.org/) configs), instead of hard-coding paths like `../node_modules/@buildit/gravity-ui-sass/some/file.ext`. The build API is part of this package's public API surface, but the actual assets file names and locations are not. So, if `gravity.css` was renamed to `foo.css` in a future release, that would _not_ be considered a breaking change. However, renaming or remoing the `distCssFilename` property of the build API _would_ be a breaking change.
+Projects that use Gravity's UI library are **strongly encouraged** to use this API within their build scripts (e.g. [Gulp](https://gulpjs.com/) files or [Webpack](https://webpack.js.org/) configs), instead of hard-coding paths like `../node_modules/@buildit/gravity-ui-web/some/file.ext`. The build API is part of this package's public API surface, but the actual assets file names and locations are not. So, if `gravity.css` was renamed to `foo.css` in a future release, that would _not_ be considered a breaking change. However, renaming or remoing the `distCssFilename` property of the build API _would_ be a breaking change.
 
 ⚠️ **Note:** The build API is strictly intended for build-time scripts and tools. It should never be embedded into your actual build artefacts.
 
 ## Using the API
-Simply `require()` (or `import`) `@buildit/gravity-ui-sass/build-api` and then use the properties and functions of the object you receive:
+Simply `require()` (or `import`) `@buildit/gravity-ui-web/build-api` and then use the properties and functions of the object you receive:
 
 ```js
-const gravityPaths = require('@buildit/gravity-ui-sass/build-api');
+const gravityPaths = require('@buildit/gravity-ui-web/build-api');
 
 // === Metadata ===
 console.log(gravityPaths.version); // The Gravity version you have installed. E.g. '0.12.0'
@@ -27,17 +27,17 @@ console.log( gravityPaths.distJsFilename ); // Filename of main JS file. E.g. 'g
 
 // For example:
 console.log( gravityPaths.distPath(gravityPaths.distCssFilename) );
-// Will output something like: '/Users/xy123456/code/gravity-ui-sass/dist/ui-lib/gravity.css'
+// Will output something like: '/Users/xy123456/code/gravity-ui-web/dist/ui-lib/gravity.css'
 
 // If invoked with no arguments, it returns the path to the distributables directory:
 console.log( gravityPaths.distPath() );
-// Will output something like: '/Users/xy123456/code/gravity-ui-sass/dist/ui-lib'
+// Will output something like: '/Users/xy123456/code/gravity-ui-web/dist/ui-lib'
 
 // If invoked with multiple arguments, they are treated as path segments relative to the
 // distributables directory. This can be useful for constructing globs that have the
 // correct path separators for your OS:
 console.log( gravityPaths.distPath('**', '*.css') );
-// Will output something like: '/Users/xy123456/code/gravity-ui-sass/dist/ui-lib/**/*.css'
+// Will output something like: '/Users/xy123456/code/gravity-ui-web/dist/ui-lib/**/*.css'
 
 
 // === SASS source code ===
@@ -48,9 +48,9 @@ console.log( gravityPaths.srcSassDebugFilename ); // Filename of debug SASS file
 // to any file in SASS source directory. It behaves exactly like the distPath() counterpart
 // described above:
 
-console.log( gravityPaths.srcSassPath() ); // '/Users/xy123456/code/gravity-ui-sass/src/ui-lib/sass
-console.log( gravityPaths.srcSassPath(gravityPaths.srcSassMainFilename) ); // '/Users/xy123456/code/gravity-ui-sass/src/ui-lib/sass/index.scss'
-console.log( gravityPaths.srcSassPath('**', '*.scss') ); // '/Users/xy123456/code/gravity-ui-sass/src/ui-lib/sass/**/*.scss'
+console.log( gravityPaths.srcSassPath() ); // '/Users/xy123456/code/gravity-ui-web/src/ui-lib/sass
+console.log( gravityPaths.srcSassPath(gravityPaths.srcSassMainFilename) ); // '/Users/xy123456/code/gravity-ui-web/src/ui-lib/sass/index.scss'
+console.log( gravityPaths.srcSassPath('**', '*.scss') ); // '/Users/xy123456/code/gravity-ui-web/src/ui-lib/sass/**/*.scss'
 ```
 
 ## Gulp example
@@ -61,7 +61,7 @@ Here's a simple example of how you might use this API within a Gulp build script
 
 const path = require('path');
 const gulp = require('gulp');
-const gravityPaths = require('@buildit/gravity-ui-sass/build-api');
+const gravityPaths = require('@buildit/gravity-ui-web/build-api');
 
 // This project's build output dir
 const buildDir = path.resolve(__dirname, 'public');
@@ -84,6 +84,6 @@ module.exports = {
 };
 ```
 
-⚠️ **Note on SASS compilation:** When compiling your own SASS, it may be tempting to simply point the SASS compiler at `gravityPaths.srcSassMainFilename` (or to add `gravityPaths.srcSassPath()` to Node SASS's `inludePaths` and then `@import "gravity-ui-sass";` in one of your own SASS files). However, this alone will not work. Gravity's SASS depends on a few external SASS libraries (`@buildit/gravy`, `modularscale-sass` & `normalize-scss`). You must therefore ensure that each library's SASS directory is also added to the Node SASS's `includePaths` option.
+⚠️ **Note on SASS compilation:** When compiling your own SASS, it may be tempting to simply point the SASS compiler at `gravityPaths.srcSassMainFilename` (or to add `gravityPaths.srcSassPath()` to Node SASS's `inludePaths` and then `@import "gravity-ui-web";` in one of your own SASS files). However, this alone will not work. Gravity's SASS depends on a few external SASS libraries (`@buildit/gravy`, `modularscale-sass` & `normalize-scss`). You must therefore ensure that each library's SASS directory is also added to the Node SASS's `includePaths` option.
 
 Note that Gravity itself and all of those SASS libraries support [Eyeglass](https://github.com/linkedin/eyeglass) which avoids the need to manually set the `includePaths` like that. We therefore recommend using Eyeglass to simplify your SASS build configuration.

--- a/docs/travis-ci.md
+++ b/docs/travis-ci.md
@@ -80,7 +80,7 @@ You must be logged-in on the Travis-CI CLI in order to link your CLI environment
 Run the following command to encrypt the NPM API key:
 
 ```bash
-> travis encrypt <API_KEY> -r buildit/gravity-ui-sass --org
+> travis encrypt <API_KEY> -r buildit/gravity-ui-web --org
 ```
 
 > **NOTE**: Do not use the `--add env.global` or any other permutation to the `travis encrypt` command, as it may overwrite other variables in your .travis.yml file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@buildit/gravity-ui-sass",
+  "name": "@buildit/gravity-ui-web",
   "version": "0.12.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@buildit/gravity-ui-sass",
+  "name": "@buildit/gravity-ui-web",
   "version": "0.12.1",
-  "description": "A SASS UI library from the Buildit's Gravity design system",
+  "description": "Library of styles, components and associated assets to build UIs for the web. Part of Buildit's Gravity design system.",
   "main": "dist/ui-lib/gravity.js",
   "files": [
     "build-api.js",
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/buildit/gravity-ui-sass.git"
+    "url": "https://github.com/buildit/gravity-ui-web.git"
   },
   "keywords": [
     "eyeglass-module",
@@ -52,9 +52,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/buildit/gravity-ui-sass/issues"
+    "url": "https://github.com/buildit/gravity-ui-web/issues"
   },
-  "homepage": "https://github.com/buildit/gravity-ui-sass#readme",
+  "homepage": "https://github.com/buildit/gravity-ui-web#readme",
   "publishConfig": {
     "access": "public"
   },
@@ -100,7 +100,7 @@
   },
   "eyeglass": {
     "sassDir": "src/ui-lib/sass",
-    "name": "gravity-ui-sass",
+    "name": "gravity-ui-web",
     "exports": "eyeglass-exports.js",
     "needs": "^1.4.1 || ^2.0.0"
   },

--- a/src/styleguide/_patterns/00-particles/05-logos-and-icons/00-svg-symbols.md
+++ b/src/styleguide/_patterns/00-particles/05-logos-and-icons/00-svg-symbols.md
@@ -1,6 +1,6 @@
 ## Consuming SVG symbols
 
-`gravity-ui-sass` provides all the logos and icons shown here, as SVG `<symbol>` elements in the `symbols.svg` file. The contents of that file must be _inlined_ into your HTML document.
+`gravity-ui-web` provides all the logos and icons shown here, as SVG `<symbol>` elements in the `symbols.svg` file. The contents of that file must be _inlined_ into your HTML document.
 
 Then, whereever individual logos or icons need to be displayed, you can do so using the following markup:
 
@@ -22,7 +22,7 @@ Without further styling, the logo or icon will appear as black (`#000`) on a tra
 
 ## Generating the SVG symbols
 
-`gravity-ui-sass` uses an SVG icon system instead of an icon font. Furthermore, [we use `<symbols>` rather than `<defs>`](https://css-tricks.com/svg-symbol-good-choice-icons/), so that we don't need to specify the `viewBox` each time a glyph is referenced. The benefits of this approach are covered in the CSS-Tricks [Icon System with SVG Sprites](https://css-tricks.com/svg-sprites-use-better-icon-fonts/) article. Of particular appeal to us were the following:
+`gravity-ui-web` uses an SVG icon system instead of an icon font. Furthermore, [we use `<symbols>` rather than `<defs>`](https://css-tricks.com/svg-symbol-good-choice-icons/), so that we don't need to specify the `viewBox` each time a glyph is referenced. The benefits of this approach are covered in the CSS-Tricks [Icon System with SVG Sprites](https://css-tricks.com/svg-sprites-use-better-icon-fonts/) article. Of particular appeal to us were the following:
 
 * Richer styling control via CSS than what you can achieve with icon font glyphs.
 * Easier positioning and sizing since it behaves more like an image and avoids inline quirkiness (line-heights, vertical positioning, etc.)

--- a/src/styleguide/_patterns/01-atoms/00-inline-text/15-input.json
+++ b/src/styleguide/_patterns/01-atoms/00-inline-text/15-input.json
@@ -1,3 +1,3 @@
 {
-  "text": "npm install @buildit/gravity-ui-sass"
+  "text": "npm install @buildit/gravity-ui-web"
 }

--- a/src/styleguide/_patterns/01-atoms/04-media/01-inline-svg-symbol.md
+++ b/src/styleguide/_patterns/01-atoms/04-media/01-inline-svg-symbol.md
@@ -17,7 +17,7 @@ One of the main reasons for inlining SVGs, is that the page's CSS can also style
 ## Usage in Gravity
 
 
-Gravity's `gravity-ui-sass` library provides a range of logos and icons as SVG `<symbol>`s in its `symbols.svg` file, which is intended to be inlined into HTML documents. This UI element is then used to display one of the available symbols.
+Gravity's `gravity-ui-web` library provides a range of logos and icons as SVG `<symbol>`s in its `symbols.svg` file, which is intended to be inlined into HTML documents. This UI element is then used to display one of the available symbols.
 
 Refer to _**Particles** > **Logos and Icons** > **SVG symbols**_ for a complete list of all available logos and icons and their respective IDs.
 

--- a/src/styleguide/_patterns/01-atoms/06-buttons/01-toggle-button.md
+++ b/src/styleguide/_patterns/01-atoms/06-buttons/01-toggle-button.md
@@ -15,7 +15,7 @@ Toggle buttons must use the `aria-pressed` attribute to denote pressed (`true`) 
 
 Currently, browsers will not automatically toggle that attribute when the button is clicked, so some JavaScript is required to make it work. Essentially, all it needs to do is react to the button element's `click` event (which is triggered not only by mouse clicks but also screen taps and keyboard input) and toggle the value of the `aria-pressed` attribute between `true` and `false`.
 
-`gravity-ui-sass`'s simple JS library (`gravity.js`) implements this behaviour and may be used as a reference.
+`gravity-ui-web`'s simple JS library (`gravity.js`) implements this behaviour and may be used as a reference.
 
 
 ## See also


### PR DESCRIPTION
**Description**
BREAKING CHANGE: NPM package has been renamed from `@buildit/gravity-ui-sass` to
`@buildit/gravity-ui-web`.

fix #201

Note to reviewers: Until we rename the git repo, some of the links in the docs will be broken.