### PR TITLE
Greenkeeper/eyeglass 2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -571,9 +571,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.12.2",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-          "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+          "version": "3.13.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+          "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -4197,9 +4197,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.12.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-          "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+          "version": "3.13.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+          "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -5148,9 +5148,9 @@
       "dev": true
     },
     "eyeglass": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/eyeglass/-/eyeglass-2.2.1.tgz",
-      "integrity": "sha512-x4jrR/IurmpKAgPUVdtZb3f1ocZOIOwQQ6Go10pghtl2LQFM+NB6p8hyOWOKkq47OMl3x5gTq6UtWSIBBY81Xw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eyeglass/-/eyeglass-2.4.0.tgz",
+      "integrity": "sha512-bAmQadXpC1d2tonoPHzCPN7WsEu/MrZTF2B0MDu/XMxh0h6HWX3Sr11K9C+x6cKCfyvi6fsOznEyyIqOa28Xdg==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
@@ -5159,9 +5159,11 @@
         "ensure-symlink": "^1.0.2",
         "fs-extra": "^7.0.0",
         "glob": "^7.1.0",
+        "heimdalljs": "^0.2.6",
         "json-stable-stringify": "^1.0.1",
         "lodash.includes": "^4.3.0",
         "lodash.merge": "^4.6.1",
+        "lru-cache": "^5.1.1",
         "node-sass": "^4.0.0 || ^3.10.1",
         "node-sass-utils": "^1.1.2",
         "semver": "^5.6.0"
@@ -5210,10 +5212,25 @@
             "graceful-fs": "^4.1.6"
           }
         },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true
         }
       }
@@ -8481,6 +8498,15 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "heimdalljs": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.6.tgz",
+      "integrity": "sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==",
+      "dev": true,
+      "requires": {
+        "rsvp": "~3.2.1"
       }
     },
     "hogan.js": {
@@ -17529,6 +17555,12 @@
         }
       }
     },
+    "rsvp": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+      "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
+      "dev": true
+    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -19420,9 +19452,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.12.2",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-          "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+          "version": "3.13.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+          "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "commitizen": "^3.0.7",
     "cz-conventional-changelog": "^2.1.0",
     "del": "^4.0.0",
-    "eyeglass": "2.2.1",
+    "eyeglass": "2.4.0",
     "gulp": "^4.0.0",
     "gulp-cheerio": "^0.6.3",
     "gulp-filter": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "commitizen": "^3.0.7",
     "cz-conventional-changelog": "^2.1.0",
     "del": "^4.0.0",
-    "eyeglass": "2.4.0",
+    "eyeglass": "^2.4.0",
     "gulp": "^4.0.0",
     "gulp-cheerio": "^0.6.3",
     "gulp-filter": "^5.1.0",


### PR DESCRIPTION
Eyeglass 2.4.0 fixes the issue that caused us to pin it to 2.2.1 (see PR #199). This PR therefore upgrades up to 2.4.0